### PR TITLE
Add config generate subcommand functionality 

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/balmanrawat/cfn-compose/config"
+	"github.com/balmanrawat/cfn-compose/cfn"
 	"github.com/balmanrawat/cfn-compose/compose"
+	"gopkg.in/yaml.v2"
 	"errors"
 	"fmt"
 )
@@ -54,6 +56,68 @@ var listCmd = &cobra.Command{
 		
 		jobsMap := compose.SortJobs(cc.Jobs)
 		compose.PrintJobsMap(jobsMap)
+
+		return nil
+	},
+}
+
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "generates configuration template",
+	Aliases: []string{"gen"},
+	Long:  `generates the sample bootstrap template to speed up the process`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sampleConfig := config.ComposeConfig {
+			Description: "Sample CloudFormation Compose file",
+			Vars: map[string]string{"ENV_TYPE": "nonproduction"},
+			Jobs: map[string]config.Job{
+				"DataStore": config.Job{
+					Name: "DataStore",
+					Description: "Creates Database and Security Group",
+					Order: 0,
+					Stacks: []cfn.Stack{
+						cfn.Stack{
+							StackName: "sample-database-network",
+							TemplateFile: "path-to-database-network-cfn-template",
+							Parameters: map[string]string{"DatabaseName": "sample-database-network"},
+							Tags: map[string]string{"Name": "sample-database-network"},
+						},
+						cfn.Stack{
+							StackName: "sample-database-stack",
+							TemplateFile: "path-to-database-cfn-template",
+							Parameters: map[string]string{"DatabaseName": "sample-database"},
+							Tags: map[string]string{"Name": "sample-database"},
+						},
+					},
+				},
+				"LambdaJob": config.Job{
+					Name: "LambdaJob",
+					Description: "Deploy lambda that uses above datastore",
+					Order: 1,
+					Stacks: []cfn.Stack{
+						cfn.Stack{
+							StackName: "lambda-sqs-stack",
+							TemplateFile: "path-to-lambda-sqs-template",
+							Parameters: map[string]string{"DelaySeconds": "5"},
+							Tags: map[string]string{"Name": "lamdbda-publisher-sqs"},
+						},
+						cfn.Stack{
+							StackName: "database-consumer-lambda-stack",
+							TemplateFile: "path-to-lambda-cfn-template",
+							Parameters: map[string]string{"LambdaName": "database-consumer-lambda"},
+							Tags: map[string]string{"Name": "database-consumer-lambda"},
+						},
+					},
+				},
+			},
+		}
+
+		d, err := yaml.Marshal(&sampleConfig)
+		if err != nil {
+			return errors.New(fmt.Sprintf("Failed to generate sample compose file: %s\n", err.Error()))
+		}
+
+		fmt.Printf("### SAMPLE TEMPLATE ###\n%s", d)
 
 		return nil
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	configCmd.AddCommand(validateCmd)
 	configCmd.AddCommand(listCmd)
+	configCmd.AddCommand(generateCmd)
 }
 
 func Execute() {
@@ -38,5 +39,3 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-
-


### PR DESCRIPTION
To speed up the process `config generate/gen` will generate bootstraping sample template. The template examples creates compose file with two jobs and four stacks. 
- First job is the template to create imaginary database network and database
- Second job is the template to create imaginary SQS queue and lambda

**Example Config generation**
<img width="569" alt="Screen Shot 2022-12-19 at 15 12 15" src="https://user-images.githubusercontent.com/8892649/208392757-347b0ea1-8208-4cde-9089-55a0e545aa66.png">
