### PR TITLE
[CFN-COMPOSE] Configurable number of goroutines

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -17,7 +17,7 @@ var deployCmd = &cobra.Command{
 			DeployMode:       true,
 			DryRun:           dryRun,
 			ConfigFile:       configFile,
-			NumberOfWorkers:  numberOfWorkers,
+			WorkersCount:     workersCount,
 		}
 
 		c.PrintConfig()

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -17,6 +17,7 @@ var deployCmd = &cobra.Command{
 			DeployMode:       true,
 			DryRun:           dryRun,
 			ConfigFile:       configFile,
+			NumberOfWorkers:  numberOfWorkers,
 		}
 
 		c.PrintConfig()

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -17,7 +17,7 @@ var destroyCmd = &cobra.Command{
 			DeployMode:       false,
 			DryRun:           dryRun,
 			ConfigFile:       configFile,
-			NumberOfWorkers:  numberOfWorkers,
+			WorkersCount:     workersCount,
 		}
 
 		c.PrintConfig()

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -17,6 +17,7 @@ var destroyCmd = &cobra.Command{
 			DeployMode:       false,
 			DryRun:           dryRun,
 			ConfigFile:       configFile,
+			NumberOfWorkers:  numberOfWorkers,
 		}
 
 		c.PrintConfig()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ var configFile string
 var logLevel string
 var dryRun bool
 var flowName string
-var numberOfWorkers int
+var workersCount int
 
 var rootCmd = &cobra.Command{
 	Use:     "cfnc",
@@ -24,10 +24,9 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "loglevel", "l", "INFO", "Specify Log Levels. Valid Levels are: DEBUG, INFO, WARN, ERROR")
 	rootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "Run commands in dry run mode")
 	deployCmd.PersistentFlags().StringVarP(&flowName, "flow", "f", "", "Cherry pick flow name that you want to deploy")
-	deployCmd.PersistentFlags().IntVarP(&numberOfWorkers, "workers", "w", 0, "Number of concurrent workers that you want to spin")
+	deployCmd.PersistentFlags().IntVarP(&workersCount, "workers", "w", 0, "Number of concurrent workers that you want to spin")
 	destroyCmd.PersistentFlags().StringVarP(&flowName, "flow", "f", "", "Cherry pick flow name that you want to destroy")
-	destroyCmd.PersistentFlags().IntVarP(&numberOfWorkers, "workers", "w", 0, "Number of concurrent workers that you want to spin")
-
+	destroyCmd.PersistentFlags().IntVarP(&workersCount, "workers", "w", 0, "Number of concurrent workers that you want to spin")
 	rootCmd.AddCommand(deployCmd)
 	rootCmd.AddCommand(destroyCmd)
 	rootCmd.AddCommand(configCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ var configFile string
 var logLevel string
 var dryRun bool
 var flowName string
+var numberOfWorkers int
 
 var rootCmd = &cobra.Command{
 	Use:     "cfnc",
@@ -23,7 +24,9 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "loglevel", "l", "INFO", "Specify Log Levels. Valid Levels are: DEBUG, INFO, WARN, ERROR")
 	rootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "Run commands in dry run mode")
 	deployCmd.PersistentFlags().StringVarP(&flowName, "flow", "f", "", "Cherry pick flow name that you want to deploy")
+	deployCmd.PersistentFlags().IntVarP(&numberOfWorkers, "workers", "w", 0, "Number of concurrent workers that you want to spin")
 	destroyCmd.PersistentFlags().StringVarP(&flowName, "flow", "f", "", "Cherry pick flow name that you want to destroy")
+	destroyCmd.PersistentFlags().IntVarP(&numberOfWorkers, "workers", "w", 0, "Number of concurrent workers that you want to spin")
 
 	rootCmd.AddCommand(deployCmd)
 	rootCmd.AddCommand(destroyCmd)

--- a/compose/compose_test.go
+++ b/compose/compose_test.go
@@ -2,8 +2,9 @@ package compose
 
 import (
 	"fmt"
-	"github.com/rbalman/cfn-compose/cfn"
 	"testing"
+
+	"github.com/rbalman/cfn-compose/cfn"
 )
 
 func TestValidateComposeConfig(t *testing.T) {
@@ -28,6 +29,28 @@ func TestValidateComposeConfig(t *testing.T) {
 				t.Fatal(fmt.Sprintf("Expected stacks[%d] and rs[%d] to be equal but got %s and %s", i, j, sName, rsName))
 			}
 			j++
+		}
+	}
+}
+
+func TestGetWorkersCount(t *testing.T) {
+	testCases := []struct {
+		flowsCount     int
+		countFromFlag  int
+		expectedResult int
+	}{
+		{0, 5, 0},
+		{10, -5, 10},
+		{10, 15, 10},
+		{5, 3, 3},
+		{8, 0, 8},
+		{7, 7, 7},
+	}
+
+	for _, testCase := range testCases {
+		actualResult := getWorkersCount(testCase.flowsCount, testCase.countFromFlag)
+		if actualResult != testCase.expectedResult {
+			t.Errorf("Test case failed: expected %d but got %d (flowsCount=%d, countFromFlag=%d)", testCase.expectedResult, actualResult, testCase.flowsCount, testCase.countFromFlag)
 		}
 	}
 }

--- a/compose/composer.go
+++ b/compose/composer.go
@@ -223,6 +223,7 @@ func executeFlow(ctx context.Context, taskC chan Task, resultsChan chan Result, 
 	}
 }
 
+// TODO: add unit test for this
 func getMaxNumberOfWorkers(totalFlows, numberFromFlag int) int {
 	if numberFromFlag == 0 || totalFlows <= numberFromFlag {
 		return totalFlows

--- a/compose/composer.go
+++ b/compose/composer.go
@@ -3,13 +3,14 @@ package compose
 import (
 	"context"
 	"fmt"
+	"os"
+	"sort"
+	"time"
+
 	"github.com/rbalman/cfn-compose/cfn"
 	"github.com/rbalman/cfn-compose/config"
 	"github.com/rbalman/cfn-compose/libs"
 	"github.com/rbalman/cfn-compose/logger"
-	"os"
-	"sort"
-	"time"
 )
 
 // var colors []string = []string{log.Blue, log.Yellow, log.Green, log.Magenta, log.Cyan}
@@ -29,6 +30,7 @@ type Composer struct {
 	DeployMode       bool
 	DryRun           bool
 	ConfigFile       string
+	NumberOfWorkers  int
 }
 
 func (c *Composer) Apply() {
@@ -86,11 +88,13 @@ func (c *Composer) Apply() {
 
 	cfnTask := make(chan Task)
 	resultsChan := make(chan Result)
+	numWorkers := getMaxNumberOfWorkers(len(cc.Flows), c.NumberOfWorkers)
 	//Generate the worker pool as pre the flow counts
-	for i := 0; i < len(cc.Flows); i++ {
+	for i := 0; i < numWorkers; i++ {
 		go executeFlow(ctx, cfnTask, resultsChan, i)
 	}
 	logger.Log.Debugf("TOTAL FLOW COUNT: %d\n", len(cc.Flows))
+	logger.Log.Debugf("TOTAL WORKERS SPUN: %d\n", numWorkers)
 	//Dispatch Flows based on the Order
 	for _, order := range orders {
 		flows, ok := flowsMap[order]
@@ -120,6 +124,19 @@ func (c *Composer) Apply() {
 	}
 
 	logger.Log.Infoln("Successfully Completed!!")
+}
+
+func (c *Composer) PrintConfig() {
+	fmt.Println("##########################")
+	fmt.Println("# Compose Configuration #")
+	fmt.Println("##########################")
+	fmt.Printf("ConfigFile: %s\n", c.ConfigFile)
+	if c.CherryPickedFlow != "" {
+		fmt.Printf("Selected Flow: %s\n", c.CherryPickedFlow)
+	}
+	fmt.Printf("DryRun: %t\n", c.DryRun)
+	fmt.Printf("LogLevel: %s\n", c.LogLevel)
+	fmt.Printf("DeployMode: %t\n\n", c.DeployMode)
 }
 
 func SortFlows(flows map[string]config.Flow) map[int][]config.Flow {
@@ -206,15 +223,9 @@ func executeFlow(ctx context.Context, taskC chan Task, resultsChan chan Result, 
 	}
 }
 
-func (c *Composer) PrintConfig() {
-	fmt.Println("##########################")
-	fmt.Println("# Compose Configuration #")
-	fmt.Println("##########################")
-	fmt.Printf("ConfigFile: %s\n", c.ConfigFile)
-	if c.CherryPickedFlow != "" {
-		fmt.Printf("Selected Flow: %s\n", c.CherryPickedFlow)
+func getMaxNumberOfWorkers(totalFlows, numberFromFlag int) int {
+	if numberFromFlag == 0 || totalFlows <= numberFromFlag {
+		return totalFlows
 	}
-	fmt.Printf("DryRun: %t\n", c.DryRun)
-	fmt.Printf("LogLevel: %s\n", c.LogLevel)
-	fmt.Printf("DeployMode: %t\n\n", c.DeployMode)
+	return numberFromFlag
 }

--- a/compose/composer.go
+++ b/compose/composer.go
@@ -30,7 +30,7 @@ type Composer struct {
 	DeployMode       bool
 	DryRun           bool
 	ConfigFile       string
-	NumberOfWorkers  int
+	WorkersCount     int
 }
 
 func (c *Composer) Apply() {
@@ -88,7 +88,7 @@ func (c *Composer) Apply() {
 
 	cfnTask := make(chan Task)
 	resultsChan := make(chan Result)
-	numWorkers := getMaxNumberOfWorkers(len(cc.Flows), c.NumberOfWorkers)
+	numWorkers := getWorkersCount(len(cc.Flows), c.WorkersCount)
 	//Generate the worker pool as pre the flow counts
 	for i := 0; i < numWorkers; i++ {
 		go executeFlow(ctx, cfnTask, resultsChan, i)
@@ -136,6 +136,7 @@ func (c *Composer) PrintConfig() {
 	}
 	fmt.Printf("DryRun: %t\n", c.DryRun)
 	fmt.Printf("LogLevel: %s\n", c.LogLevel)
+	fmt.Printf("WorkersCount: %d\n", c.WorkersCount)
 	fmt.Printf("DeployMode: %t\n\n", c.DeployMode)
 }
 
@@ -223,10 +224,9 @@ func executeFlow(ctx context.Context, taskC chan Task, resultsChan chan Result, 
 	}
 }
 
-// TODO: add unit test for this
-func getMaxNumberOfWorkers(totalFlows, numberFromFlag int) int {
-	if numberFromFlag == 0 || totalFlows <= numberFromFlag {
-		return totalFlows
+func getWorkersCount(flowsCount, countFromFlag int) int {
+	if countFromFlag <= 0 || countFromFlag > flowsCount {
+		return flowsCount
 	}
-	return numberFromFlag
+	return countFromFlag
 }


### PR DESCRIPTION
##### SUMMARY

- Add an integer flag: `-w` or `--workers` to `deploy` and `destroy` command
- Determine the number of workers to spin based on total flows on compose file vs number of workers sent through flag argument

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
