### PR TITLE
Support for running cfnc in docker containers

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,21 @@
+name: Push Docker Image to DockerHub
+
+on:
+  push:
+    branches: [ master, main]
+
+jobs:
+  dockerhub:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Login to DockerHub
+      env:
+        DOCKER_USER: ${{secrets.DOCKER_USER}}
+        DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      run: |
+        docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+    - name: Build and Push the cfnc Image
+      run: |
+        docker build -t omegazyadav/cfnc:${{ github.sha }} .
+        docker push omegazyadav/cfnc:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.19 as builder
 
 WORKDIR /app
 
@@ -8,6 +8,10 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o /cfnc
+RUN CGO_ENABLED=0 GOOS=linux go build -o cfnc
+
+FROM scratch as final
+
+COPY --from=builder /app/cfnc /cfnc
 
 ENTRYPOINT [ "/cfnc" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.19
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /cfnc
+
+ENTRYPOINT [ "/cfnc" ]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Binary is available for Linux, Windows and Mac OS (amd64 and arm64). Download th
 go install github.com/rbalman/cfn-compose@latest
 ```
 
+## Run with Docker
+```shell
+docker pull omegazyadav/cfnc
+docker run --rm --name cfnc omegazyadav/cfnc
+```
 
 ## Limitations
 * Supports limited CFN attributes


### PR DESCRIPTION
## Summary 
- dockerize the cfnc as a executable container
-  publish it in the registry and update the CI

## Screenshots
![Screenshot from 2023-06-18 18-13-41](https://github.com/rbalman/cfn-compose/assets/31333363/7621f064-7fb5-45a4-900a-faef4152f16d)


Closes #32 